### PR TITLE
[enh] avoid silent fail during archiving

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -82,6 +82,10 @@ $(document).ready(function(){
             href,
              {} ,
             function(data){ 
+                if (data.indexOf("OK") == -1) {
+                    alert("Failed to archive item: " + data);
+                    return;
+                }
                 div.hide('slow');
              } 
          );  


### PR DESCRIPTION
Before this commit, clicking on the `Archive` link hid the item after
getting a response from the server -- regardless of the content. This
commit adds a check to ensure that the user won't be surprised at the
next reload to see his/her "archived" items shown again.
