### PR TITLE
opml import

### DIFF
--- a/opml_import.py
+++ b/opml_import.py
@@ -1,0 +1,14 @@
+from models import Feed
+
+def import_outline_element(o):
+    for f in o:
+        if hasattr(f,'xmlUrl'):
+            new = Feed.objects.create(url = f.xmlUrl,
+                                  #tags = self.cleaned_data['tags'],
+                                  name = f.title,
+                                  )
+            new.save()
+        else:
+            import_outline_element(f)
+
+

--- a/views.py
+++ b/views.py
@@ -95,14 +95,10 @@ def bulk_archive(request):
 
 def opml_import(request, url):
     import opml
+    from opml_import import import_outline_element
     try:
         o = opml.parse(url)
     except:
         return HttpResponse('Cannot parse opml file %s' % url)
-    for f in o:
-        new = Feed.objects.create(url = f.xmlUrl,
-                                  #tags = self.cleaned_data['tags'],
-                                  name = f.title,
-                                  )
-        new.save()
+    import_outline_element(o)
     return HttpResponse('OK')


### PR DESCRIPTION
if the opml file is structured(typically greader ordered to directories), then directory elements doesn't have xmlurl property, but child elements - import needs recursivity
