### PR TITLE
[fix] hide Archive link on archived items

### DIFF
--- a/media/css/style.css
+++ b/media/css/style.css
@@ -23,6 +23,7 @@ div#calendar { float: right; margin-right: 40px; width: 60%; }
 
 .archived { background: #222222; color: grey; }
 .item { font-family: monospace; }
+.archived a.archive { display: none; }
 
 a { color: #FF0066; text-decoration: none; }
 a:hover { text-decoration: underline; }


### PR DESCRIPTION
The Archive link is shown even on archived items, which is not only useless (clicking on it doesn't change anything but removes it from the page), but also makes searching for unread items using in-browser search harder.
